### PR TITLE
Fix click listeners not working: Use readonly instead of disabled for inputs

### DIFF
--- a/src/panel.ts
+++ b/src/panel.ts
@@ -100,7 +100,7 @@ export class Panel {
           style="height:${this._settings.lineHeight}px;min-width:${this._settings.minFavWidth}px;max-width:${this._settings.maxFavWidth}px;background:${bg};border-color:${dividerColor};">
           <span class="favorite-inner" style="border-color:${dividerColor};">
             ${typeIconHtml}
-            <input class="title" title="${favorite.title}" value="${favorite.title}" style="color:${fg};" disabled></input>
+            <input class="title" title="${favorite.title}" value="${favorite.title}" style="color:${fg};" readonly></input>
             <span class="controls" style="background:${hoverBg};">
               <span class="rename fas fa-pen" title="Rename" style="color:${fg};"></span>
               <span class="delete fas fa-trash" title="Delete" style="color:${fg};"></span>

--- a/src/webview.css
+++ b/src/webview.css
@@ -76,7 +76,7 @@ input.title:hover {
   background: none;
   cursor: default;
 }
-input.title:focus {
+input.title:not([readonly]):focus {
   border-color: var(--joplin-warning-background-color);
   border-radius: 3px;
   border-style: solid;
@@ -84,6 +84,9 @@ input.title:focus {
   margin-right: 8px;
   outline: none;
   padding: 3px 1px;
+}
+input.title[readonly]:focus {
+  outline: none;
 }
 
 .controls {

--- a/src/webview.js
+++ b/src/webview.js
@@ -46,7 +46,7 @@ function openDialog(event) {
 
 function enableEdit(element, value) {
   editStarted = value;
-  element.disabled = (!value);
+  element.readOnly = (!value);
   element.focus();
   element.select();
 }


### PR DESCRIPTION
# Summary

This pull request should fix #26. It seems that in Electron 26, click handlers on ancestors of disabled elements work differently than in earlier versions of Electron. [See this Chromium bug report](https://bugs.chromium.org/p/chromium/issues/detail?id=1477379&q=disabled%20input%20click&can=2).

# Testing

Here is a list of steps I've followed to test this change:
1. Add the favorites plugin as a development plugin
2. Add 2-3 favorite notes
3. Switch between the notes by clicking on them in the favorites panel
4. Rename one of the notes by clicking the "edit" button

This has been tested in Joplin 2.12.19 and 2.13.5.