### PR TITLE
Add a new quick jump feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- None
+## [1.4.0] - 2025-12-31
+
+### Added
+
+- Quick jump keyboard shortcuts (Cmd+1~9 on macOS, Ctrl+1~9 on Windows/Linux) to jump to the first 9 favorite items
+  - Works for all favorite types (notebooks, notes, todos, tags, searches)
+  - Shortcuts are automatically configured and can be customized in Settings > Keyboard Shortcuts
 
 ## [1.3.2] - 2023-11-19
 

--- a/README.md
+++ b/README.md
@@ -147,11 +147,31 @@ This plugin provides additional commands as described in the following table.
 | Add search to Favorites           | `favsAddSearch`        | Add favorite with entered search query | `Tools>Favorites`, `Command palette`                                     |
 | Remove all Favorites              | `favsClear`            | Remove all favorites                   | `Tools>Favorites`, `Command palette`                                     |
 | Toggle Favorites panel visibility | `favsToggleVisibility` | Toggle panel visibility                | `Tools>Favorites`, `Command palette`                                     |
+| Jump to Favorite 1                | `favsJumpToFavorite1`  | Quick jump to first favorite           | `Tools`, `Command palette`                                               |
+| Jump to Favorite 2                | `favsJumpToFavorite2`  | Quick jump to second favorite          | `Tools`, `Command palette`                                               |
+| Jump to Favorite 3                | `favsJumpToFavorite3`  | Quick jump to third favorite           | `Tools`, `Command palette`                                               |
+| Jump to Favorite 4                | `favsJumpToFavorite4`  | Quick jump to fourth favorite          | `Tools`, `Command palette`                                               |
+| Jump to Favorite 5                | `favsJumpToFavorite5`  | Quick jump to fifth favorite           | `Tools`, `Command palette`                                               |
+| Jump to Favorite 6                | `favsJumpToFavorite6`  | Quick jump to sixth favorite           | `Tools`, `Command palette`                                               |
+| Jump to Favorite 7                | `favsJumpToFavorite7`  | Quick jump to seventh favorite         | `Tools`, `Command palette`                                               |
+| Jump to Favorite 8                | `favsJumpToFavorite8`  | Quick jump to eighth favorite          | `Tools`, `Command palette`                                               |
+| Jump to Favorite 9                | `favsJumpToFavorite9`  | Quick jump to ninth favorite           | `Tools`, `Command palette`                                               |
 
 ### Keyboard shortcuts
 
 Keyboard shortcuts can be assigned in user options via `Tools > Options > Keyboard Shortcuts` to all [commands](#commands) which are assigned to the `Tools>Favorites` menu context.
 In the keyboard shortcut editor, search for the command label where shortcuts shall be added.
+
+#### Quick Jump Shortcuts
+
+The plugin provides 9 quick jump shortcuts to access your favorite items:
+
+- **macOS**: `Cmd+1` through `Cmd+9` to jump to favorites 1-9
+- **Windows/Linux**: `Ctrl+1` through `Ctrl+9` to jump to favorites 1-9
+
+These shortcuts work for all favorite types (notebooks, notes, todos, tags, and searches). If a favorite doesn't exist at a particular position, the shortcut will be displayed in the keyboard shortcuts menu but will do nothing when pressed.
+
+The shortcuts are automatically configured and will appear in `Tools > Options > Keyboard Shortcuts`. You can customize them if desired.
 
 ## User options
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3095,6 +3095,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
       "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
       "dev": true,
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3155,6 +3156,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3451,6 +3453,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001541",
         "electron-to-chromium": "^1.4.535",
@@ -3980,6 +3983,7 @@
       "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.27.0.tgz",
       "integrity": "sha512-pPZJilfX9BxESwujODz5pydeGi+FBrXq1rcaB1mfhFXXFJ9GjE6CNndAk+8jPzoXGD+16LtSS4xlYEIUiW4Abg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "heap": "^0.2.6",
         "lodash": "^4.17.21"
@@ -4393,6 +4397,7 @@
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -4803,6 +4808,7 @@
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
       "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "iconv-lite": "^0.6.2"
       }
@@ -6617,6 +6623,7 @@
       "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
       "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "argparse": "^1.0.7",
         "entities": "~2.0.0",
@@ -8561,7 +8568,8 @@
       "version": "4.1.8",
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -8799,6 +8807,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9652,6 +9661,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9944,6 +9954,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
       "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -9991,6 +10002,7 @@
       "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-4.10.0.tgz",
       "integrity": "sha512-NLhDfH/h4O6UOy+0LSso42xvYypClINuMNBVVzX4vX98TmTaTUxwRbXdhucbFMd2qLaCTcLq/PdYrvi8onw90w==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^1.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -299,7 +299,7 @@ joplin.plugins.register({
     }
 
     // prepare commands menu
-    const commandsSubMenu: MenuItem[] = [
+    const baseMenuItems: MenuItem[] = [
       {
         commandName: 'favsAddFolder',
         label: 'Add active notebook'
@@ -326,6 +326,18 @@ joplin.plugins.register({
         accelerator: 'CmdOrCtrl+Alt+F'
       }
     ];
+
+    // Add quick jump shortcuts
+    const jumpMenuItems: MenuItem[] = [];
+    for (let i = 1; i <= 9; i++) {
+      jumpMenuItems.push({
+        commandName: `favsJumpToFavorite${i}`,
+        label: `Jump to Favorite ${i}`,
+        accelerator: `CmdOrCtrl+${i}`
+      });
+    }
+
+    const commandsSubMenu: MenuItem[] = [...baseMenuItems, ...jumpMenuItems];
     await joplin.views.menus.create('toolsFavorites', 'Favorites', commandsSubMenu, MenuItemLocation.Tools);
 
     // add commands to folders context menu
@@ -339,17 +351,6 @@ joplin.plugins.register({
 
     // add commands to editor context menu
     await joplin.views.menuItems.create('editorContextMenuAddNote', 'favsAddNote', MenuItemLocation.EditorContextMenu);
-
-    // add quick jump commands to Tools menu with keyboard shortcuts
-    // CmdOrCtrl automatically uses Cmd on Mac and Ctrl on Windows/Linux
-    for (let i = 1; i <= 9; i++) {
-      await joplin.views.menuItems.create(
-        `toolsMenuJumpToFavorite${i}`,
-        `favsJumpToFavorite${i}`,
-        MenuItemLocation.Tools,
-        { accelerator: `CmdOrCtrl+${i}` }
-      );
-    }
 
     //#endregion
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -272,7 +272,7 @@ joplin.plugins.register({
     // Desc: Toggle panel visibility
     await COMMANDS.register({
       name: 'favsToggleVisibility',
-      label: 'Toggle Favorites visibility',
+      label: 'Toggle Favorites Visibility',
       iconName: 'fas fa-eye-slash',
       execute: async () => {
         await panel.toggleVisibility();
@@ -322,7 +322,8 @@ joplin.plugins.register({
       },
       {
         commandName: 'favsToggleVisibility',
-        label: 'Toggle panel visibility'
+        label: 'Toggle panel visibility',
+        accelerator: 'CmdOrCtrl+Alt+F'
       }
     ];
     await joplin.views.menus.create('toolsFavorites', 'Favorites', commandsSubMenu, MenuItemLocation.Tools);

--- a/src/index.ts
+++ b/src/index.ts
@@ -279,6 +279,25 @@ joplin.plugins.register({
       }
     });
 
+    // Commands: favsJumpToFavorite1 through favsJumpToFavorite9
+    // Desc: Quick jump to favorite items at positions 1-9
+    for (let i = 1; i <= 9; i++) {
+      await COMMANDS.register({
+        name: `favsJumpToFavorite${i}`,
+        label: `Jump to Favorite ${i}`,
+        iconName: 'fas fa-keyboard',
+        execute: async () => {
+          const index = i - 1; // Convert to 0-based index
+          const favorite: IFavorite = favorites.get(index);
+          
+          // Only jump if favorite exists (works for all favorite types)
+          if (favorite) {
+            await COMMANDS.execute('favsOpenFavorite', index);
+          }
+        }
+      });
+    }
+
     // prepare commands menu
     const commandsSubMenu: MenuItem[] = [
       {
@@ -319,6 +338,17 @@ joplin.plugins.register({
 
     // add commands to editor context menu
     await joplin.views.menuItems.create('editorContextMenuAddNote', 'favsAddNote', MenuItemLocation.EditorContextMenu);
+
+    // add quick jump commands to Tools menu with keyboard shortcuts
+    // CmdOrCtrl automatically uses Cmd on Mac and Ctrl on Windows/Linux
+    for (let i = 1; i <= 9; i++) {
+      await joplin.views.menuItems.create(
+        `toolsMenuJumpToFavorite${i}`,
+        `favsJumpToFavorite${i}`,
+        MenuItemLocation.Tools,
+        { accelerator: `CmdOrCtrl+${i}` }
+      );
+    }
 
     //#endregion
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 1,
   "id": "joplin.plugin.benji.favorites",
   "app_min_version": "2.1.5",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "name": "Favorites",
   "description": "Save any notebook, note, to-do, tag, or search as favorite in an extra panel view for quick access.",
   "author": "Benji300",


### PR DESCRIPTION
# PR Summary

## Added: Quick Jump Keyboard Shortcuts

- Added keyboard shortcuts to jump to the first 9 favorite items:
  - `Cmd+1` through `Cmd+9` (macOS) / `Ctrl+1` through `Ctrl+9` (Windows/Linux)
  - Works for all favorite types (notebooks, notes, todos, tags, searches)
- Implemented 9 new commands (`favsJumpToFavorite1` through `favsJumpToFavorite9`) that:
  - Check if a favorite exists at the target position before jumping
  - Use the existing `favsOpenFavorite` command to maintain consistency
  - Are automatically added to the Tools > Favorites menu with their keyboard shortcuts
- Shortcuts can be customized in Settings > Keyboard Shortcuts

## Technical Details

- Commands are registered dynamically using a loop (lines 284-299)
- Menu items are created with accelerators `CmdOrCtrl+${i}` (lines 330-338)
- Index conversion from 1-based (user-facing) to 0-based (internal) is handled automatically
- All existing favorite types are supported through the unified `favsOpenFavorite` command

This feature enables quick access to frequently used favorites without opening the panel.

<img width="918" height="479" alt="image" src="https://github.com/user-attachments/assets/32893e7e-330f-498e-bf93-e329b7b7c6d1" />


